### PR TITLE
Modified PhotosExampleWithSnapkit

### DIFF
--- a/iOS/SnapKit/PhotosExampleWithSnapkit/PhotosExampleWithSnapkit/CustomCell.swift
+++ b/iOS/SnapKit/PhotosExampleWithSnapkit/PhotosExampleWithSnapkit/CustomCell.swift
@@ -12,10 +12,6 @@ class CustomCell: UITableViewCell {
     static let cellId = "customCell"
     
     let photoView = UIImageView()
-    let nextBtn = UIButton()
-    
-    //let nextIcon: UIImage = UIImage(named: "chevron.right")!
-    //nextBtn.setImage(nextIcon, for: .normal)
     
     //스토리보드로 셀을 작성하게 될 경우 초기화를 해주기 때문에 안해줘도 되지만 코드로 작성하게 될 경우에는 작성해야 한다.
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -33,20 +29,16 @@ class CustomCell: UITableViewCell {
 
     private func setViewHierarchy() {
         self.addSubview(photoView)
-        self.addSubview(nextBtn)
+        // self.addSubview(nextBtn)
+        // 기존 코드를 해석하면 cell에 photoView와 nextBtn이 올라가고 그 위에 contentView가 올라가기 때문에
+        // self.contentView.addSubview(nextBtn)로 코드를 작성해 주어야지 contentView 위에 nextBtn이 올라간다.
     }
 
     private func setConstraints() {
         photoView.snp.makeConstraints{
             $0.centerY.equalTo(self)
-            $0.left.equalTo(self).offset(20)
-            $0.size.width.height.equalTo(60)
-        }
-
-        nextBtn.snp.makeConstraints{
-            $0.leading.equalTo(self).offset(330)
-            $0.centerY.equalTo(self)
-            $0.size.width.height.equalTo(20)
+            $0.leading.equalTo(self).offset(20)
+            $0.size.equalTo(60)
         }
     }
 

--- a/iOS/SnapKit/PhotosExampleWithSnapkit/PhotosExampleWithSnapkit/ImageZoomViewController.swift
+++ b/iOS/SnapKit/PhotosExampleWithSnapkit/PhotosExampleWithSnapkit/ImageZoomViewController.swift
@@ -10,19 +10,52 @@ import Photos
 
 class ImageZoomViewController: UIViewController, UIScrollViewDelegate {
     
-    static let storyboardId = "imageZoomViewController"
+    private lazy var scrollView: UIScrollView = {
+      let view = UIScrollView()
+      // UIScrollView의 minimumZoomScale, maximumZoomScale, bounces, indicator 설정
+      view.minimumZoomScale = 1.0
+      view.maximumZoomScale = 3.0
+      view.bounces = false
+      view.showsVerticalScrollIndicator = false
+      view.showsHorizontalScrollIndicator = false
+      return view
+    }()
     
     var asset: PHAsset! //전 화면에서 받아올 이미지
     let imageManager: PHCachingImageManager = PHCachingImageManager()
     
-    weak var imageView: UIImageView!
+    private let imageView = UIImageView()
     
+    //viewForZooming(in:) 메소드 구현
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         return self.imageView
+    }
+    
+    func setViewHierarchy() {
+        self.view.addSubview(scrollView)
+        scrollView.addSubview(imageView)
+    }
+    func setConstraints() {
+        scrollView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+        imageView.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(80)
+            $0.size.size.equalTo(500)
+            //$0.bottom.equalToSuperview().offset(-100)
+            $0.leading.trailing.equalToSuperview()
+        }
+    }
+    func setLayouts() {
+        setViewHierarchy()
+        setConstraints()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        //scrollView의 delegate 할당
+        self.scrollView.delegate = self
+        view.backgroundColor = .white
 
         imageManager.requestImage(for: asset, targetSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
                                   contentMode: .aspectFill,
@@ -30,6 +63,8 @@ class ImageZoomViewController: UIViewController, UIScrollViewDelegate {
                                   resultHandler: { image, _ in
             self.imageView.image = image
         })
+        
+        setLayouts()
     }
 
 }


### PR DESCRIPTION
# 온보딩 11주차

## 피드백 반영
- equalTo(self) 보다는 equalToSuperView() 사용하기 ✅
- contentView에 뷰 요소들 유저와 상호작용 하도록 해보기 ✅
- `.width.height `또는 `size` 사용하기 ✅
- 필요없는 변수 지우기 ✅
- `private let imageView = UIImageView()` 런타임 오류 해결 ✅
- SnapKit 규칙에 따르면 left와 right보단 leading과 trailing을 지향 ✅
- 🔥 !보단 ? 사용하기 !

## 기능 구현
### PhotoExampleWithSnapKit 프로젝트 구현
- SnapKit으로 TableView 구현 완료 (yourssu 규칙에 따라서)
- 사진이미지 정사각형으로 출력
- 첫페이지에서 swipe로 이미지 delete 기능 구현하기 (근데.... swipe가 됐다가 안됐다가 하네용...ㅜㅅㅜ)
- cell 클릭하면 다음 controllerView로 넘어가기
- 다음 controllerView에서 imageZoom 기능 구현하기
- navigationbar에 refresh 아이템 추가 및 기능 구현하기